### PR TITLE
fix error with trailing space in animation .csv

### DIFF
--- a/include/csv_input_sanatiser.hpp
+++ b/include/csv_input_sanatiser.hpp
@@ -151,7 +151,8 @@ class CSV_IOstream_Sanatiser{
 			bool done = false;
 			while (!done) {
 				while ( traits_type::is_good(c = io::get(src)) && c != traits_type::newline() ) {
-					if (c != traits_type::to_char_type('\r') && c != traits_type::to_char_type('\t'))
+					if (c != traits_type::to_char_type('\r') && c != traits_type::to_char_type('\t')
+					    && c != traits_type::to_char_type(' '))
 						cur_line_ += traits_type::to_int_type(c);
 				}
 				while (columns_section && !data_section && valid_csv_line(cur_line_)) {


### PR DESCRIPTION
Hi there -- when loading animation files, if they have a trailing space on any line, one of two error messages is shown:
* Headers unsupported warning...
* Inconsistent/wrong number of columns...
There is no indication of the cause and finding the rogue white space can be challenging. 

Added a small change to ignore spaces when reading the file, though I don't know the code base well enough to know if this has further downstream effects (what are columns?, etc). 